### PR TITLE
Rails 4.2 support (specific to url_for method and aliases)

### DIFF
--- a/lib/subdomain_fu/url_rewriter.rb
+++ b/lib/subdomain_fu/url_rewriter.rb
@@ -3,14 +3,14 @@ require 'action_dispatch/routing/route_set'
 module ActionDispatch
   module Routing
     class RouteSet #:nodoc:
-      def url_for_with_subdomains(options, path_segments=nil)
+      def url_for_with_subdomains(options, route_name = nil, url_strategy = UNKNOWN)
         if SubdomainFu.needs_rewrite?(options[:subdomain], (options[:host] || (@request && @request.host_with_port))) || options[:only_path] == false
           options[:only_path] = false if SubdomainFu.override_only_path?
           options[:host] = SubdomainFu.rewrite_host_for_subdomains(options.delete(:subdomain), options[:host] || (@request && @request.host_with_port))
         else
           options.delete(:subdomain)
         end
-        url_for_without_subdomains(options)
+        url_for_without_subdomains(options, route_name, url_strategy)
       end
       alias_method_chain :url_for, :subdomains
     end

--- a/lib/subdomain_fu/url_rewriter.rb
+++ b/lib/subdomain_fu/url_rewriter.rb
@@ -3,15 +3,28 @@ require 'action_dispatch/routing/route_set'
 module ActionDispatch
   module Routing
     class RouteSet #:nodoc:
-      def url_for_with_subdomains(options, route_name = nil, url_strategy = UNKNOWN)
-        if SubdomainFu.needs_rewrite?(options[:subdomain], (options[:host] || (@request && @request.host_with_port))) || options[:only_path] == false
-          options[:only_path] = false if SubdomainFu.override_only_path?
-          options[:host] = SubdomainFu.rewrite_host_for_subdomains(options.delete(:subdomain), options[:host] || (@request && @request.host_with_port))
-        else
-          options.delete(:subdomain)
+      if ::Rails.version.to_f >= 4.2
+        def url_for_with_subdomains(options, route_name = nil, url_strategy = UNKNOWN)
+          if SubdomainFu.needs_rewrite?(options[:subdomain], (options[:host] || (@request && @request.host_with_port))) || options[:only_path] == false
+            options[:only_path] = false if SubdomainFu.override_only_path?
+            options[:host] = SubdomainFu.rewrite_host_for_subdomains(options.delete(:subdomain), options[:host] || (@request && @request.host_with_port))
+          else
+            options.delete(:subdomain)
+          end
+          url_for_without_subdomains(options, route_name, url_strategy)
         end
-        url_for_without_subdomains(options, route_name, url_strategy)
+      else
+        def url_for_with_subdomains(options, path_segments=nil)
+          if SubdomainFu.needs_rewrite?(options[:subdomain], (options[:host] || (@request && @request.host_with_port))) || options[:only_path] == false
+            options[:only_path] = false if SubdomainFu.override_only_path?
+            options[:host] = SubdomainFu.rewrite_host_for_subdomains(options.delete(:subdomain), options[:host] || (@request && @request.host_with_port))
+          else
+            options.delete(:subdomain)
+          end
+          url_for_without_subdomains(options)
+        end
       end
+      
       alias_method_chain :url_for, :subdomains
     end
   end


### PR DESCRIPTION
url_for method breaks as of rails 4.2 due to the change in the method parameters. Fixed it such that it works for 4.2 earlier versions and later versions too.
